### PR TITLE
Fix the passing through of the props meant for the components itself

### DIFF
--- a/src/Col.js
+++ b/src/Col.js
@@ -33,13 +33,17 @@ const Col = React.createClass({
       classes.push('reverse');
     }
 
+    let passingProps = {};
     for (let key in this.props) {
       if (this.props.hasOwnProperty(key) && this._classMap[key]) {
         classes.push(this._classMap[key] + this.props[key]);
       }
+      else {
+        passingProps[key] = this.props[key]
+      }
     }
 
-    return React.createElement('div', Object.assign({}, this.props, {
+    return React.createElement('div', Object.assign({}, passingProps, {
       className: classes.join(' ')
     }), this.props.children);
   }

--- a/src/Grid.js
+++ b/src/Grid.js
@@ -9,8 +9,15 @@ const Grid = React.createClass({
     const containerClass = this.props.fluid ? 'container-fluid' : 'container';
     const className = classNames(this.props.className, containerClass);
 
+    let passingProps = {};
+    for (let key in this.props) {
+      if (!this.props.hasOwnProperty(key) || !this.propTypes[key]) {
+        passingProps[key] = this.props[key]
+      }
+    }
+
     return (
-      <div {...this.props} className={className}>
+      <div {...passingProps} className={className}>
         {this.props.children}
       </div>
     );

--- a/src/Row.js
+++ b/src/Row.js
@@ -34,8 +34,15 @@ const Row = React.createClass({
 
     const className = classNames(this.props.className, modificators);
 
+    let passingProps = {};
+    for (let key in this.props) {
+      if (!this.props.hasOwnProperty(key) || !this.propTypes[key]) {
+        passingProps[key] = this.props[key]
+      }
+    }
+
     return (
-      <div {...this.props} className={className}>
+      <div {...passingProps} className={className}>
         {this.props.children}
       </div>
     );


### PR DESCRIPTION
In React 0.15.2, components should no longer pass props meant for themselves to their children using `...this.props`. 

This PR should fix that.

More can be read about the issue on https://facebook.github.io/react/warnings/unknown-prop.html
