### PR TITLE
Moved the .first and .last classes from row to col

### DIFF
--- a/src/Col.js
+++ b/src/Col.js
@@ -10,7 +10,9 @@ const Col = React.createClass({
     smOffset: React.PropTypes.number,
     mdOffset: React.PropTypes.number,
     lgOffset: React.PropTypes.number,
-    reverse: React.PropTypes.bool
+    reverse: React.PropTypes.bool,
+    first: React.PropTypes.string,
+    last: React.PropTypes.string
   },
   _classMap: {
     xs: 'col-xs-',
@@ -20,7 +22,9 @@ const Col = React.createClass({
     xsOffset: 'col-xs-offset-',
     smOffset: 'col-sm-offset-',
     mdOffset: 'col-md-offset-',
-    lgOffset: 'col-lg-offset-'
+    lgOffset: 'col-lg-offset-',
+    first: 'first-',
+    last: 'last-'
   },
   render() {
     const { reverse, className, ...other} = this.props;

--- a/src/Row.js
+++ b/src/Row.js
@@ -2,7 +2,7 @@ const React = require('react');
 const classNames = require('classnames');
 
 const ModificatorType = React.PropTypes.oneOf(['xs', 'sm', 'md', 'lg']);
-const modificatorKeys = ['start', 'center', 'end', 'top', 'middle', 'bottom', 'around', 'between', 'first', 'last'];
+const modificatorKeys = ['start', 'center', 'end', 'top', 'middle', 'bottom', 'around', 'between'];
 
 const Row = React.createClass({
   propTypes: {
@@ -15,8 +15,6 @@ const Row = React.createClass({
     bottom: ModificatorType,
     around: ModificatorType,
     between: ModificatorType,
-    first: ModificatorType,
-    last: ModificatorType
   },
   render() {
     const { reverse, className, children, ...other} = this.props;

--- a/src/Row.js
+++ b/src/Row.js
@@ -14,7 +14,7 @@ const Row = React.createClass({
     middle: ModificatorType,
     bottom: ModificatorType,
     around: ModificatorType,
-    between: ModificatorType,
+    between: ModificatorType
   },
   render() {
     const { reverse, className, children, ...other} = this.props;

--- a/src/__tests__/Col.js
+++ b/src/__tests__/Col.js
@@ -7,12 +7,14 @@ describe('Col', () => {
   const Col = require('../Col');
 
   it('Should add classes equals to props', () => {
-    const col = TestUtils.renderIntoDocument(<Col xs={12} sm={8} md={6} lg={4} />);
+    const col = TestUtils.renderIntoDocument(<Col xs={12} sm={8} md={6} lg={4} first="xs" last="lg"/>);
     const className = ReactDOM.findDOMNode(col).className;
     expect(className).toContain('col-xs-12');
     expect(className).toContain('col-sm-8');
     expect(className).toContain('col-md-6');
     expect(className).toContain('col-lg-4');
+    expect(className).toContain('first-xs');
+    expect(className).toContain('last-lg');
   });
 
   it('Should add "reverse" class if "reverse" property is true', () => {

--- a/src/__tests__/Row.js
+++ b/src/__tests__/Row.js
@@ -34,8 +34,6 @@ describe('Row', () => {
         bottom="sm"
         around="md"
         between="lg"
-        first="xs"
-        last="sm"
       />
     );
     const className = ReactDOM.findDOMNode(row).className;
@@ -49,7 +47,5 @@ describe('Row', () => {
     expect(className).toContain('bottom-sm');
     expect(className).toContain('around-md');
     expect(className).toContain('between-lg');
-    expect(className).toContain('first-xs');
-    expect(className).toContain('last-sm');
   });
 });


### PR DESCRIPTION
I moved the .first and .last class from row to col where they should be used as defined in http://flexboxgrid.com/.

Can now be used like this:

<Col xs={6} last="sm">

